### PR TITLE
It is necessary to add this flag for compilation on Windows

### DIFF
--- a/torch_utils/ops/filtered_lrelu.py
+++ b/torch_utils/ops/filtered_lrelu.py
@@ -29,6 +29,7 @@ def _init():
             headers=['filtered_lrelu.h', 'filtered_lrelu.cu'],
             source_dir=os.path.dirname(__file__),
             extra_cuda_cflags=['--use_fast_math'],
+            extra_cflags=['/std:c++17'],
         )
     return True
 


### PR DESCRIPTION
filtered_lrelu.cpp uses "if constexpr" which is c++17, and will otherwise fail with the following error.

filtered_lrelu.cpp(147): error C4984: 'if constexpr' is a C++17 language extension

Please note, I have not tested this on other platforms (e.g. Ubuntu), where this flag might be inappropriate.