### PR TITLE
Add channel `conda-forge` to `environment.yml` for Windows support

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: stylegan3
 channels:
   - pytorch
   - nvidia
+  - conda-forge
 dependencies:
   - python >= 3.8
   - pip


### PR DESCRIPTION
Currently the `nvidia` channel is missing `cudatoolkit` in version `11.1` for Windows. (https://anaconda.org/nvidia/cudatoolkit/files)
Channel `conda-forge` has these files. So I'd suggest to add this channel to the environment.yml for Windows support.


Output on Windows:
```console
foo@bar:~$ conda env create -f environment.yml

Collecting package metadata (repodata.json): done
Solving environment: failed

ResolvePackageNotFound:
  - cudatoolkit=11.1
````