### PR TITLE
avoid windows anaconda installation problems

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -10,7 +10,7 @@ dependencies:
   - pillow=8.3.1
   - scipy=1.7.1
   - pytorch=1.9.1
-  - cudatoolkit=11.1
+  - cudatoolkit>=11.1
   - requests=2.26.0
   - tqdm=4.62.2
   - ninja=1.10.2


### PR DESCRIPTION
as you know, a common scenario on windows for new users is a combination of:
anaconda + pythorch + cuda

but when installing the current releases of these from the websites, the stylegan installation fails and falls back to cpu.

for dealing with this, i suggest:
to change the "requirement" from cudatoolkit 11.1 to a "minimun" of 11.1.
so the 11.3 from the current pytorch gets accepted.

thank you.