### PR TITLE
`conda env create -f environment.yml` doesn't work

### DIFF
--- a/environment.yml
+++ b/environment.yml
@@ -2,6 +2,7 @@ name: stylegan3
 channels:
   - pytorch
   - nvidia
+  - conda-forge
 dependencies:
   - python >= 3.8
   - pip


### PR DESCRIPTION
adding conda-forge allows it to work for me on Windows 10