### PR TITLE
Update train.py

### DIFF
--- a/train.py
+++ b/train.py
@@ -189,8 +189,8 @@ def main(**kwargs):
     c = dnnlib.EasyDict() # Main config dict.
     c.G_kwargs = dnnlib.EasyDict(class_name=None, z_dim=512, w_dim=512, mapping_kwargs=dnnlib.EasyDict())
     c.D_kwargs = dnnlib.EasyDict(class_name='training.networks_stylegan2.Discriminator', block_kwargs=dnnlib.EasyDict(), mapping_kwargs=dnnlib.EasyDict(), epilogue_kwargs=dnnlib.EasyDict())
-    c.G_opt_kwargs = dnnlib.EasyDict(class_name='torch.optim.Adam', betas=[0,0.99], eps=1e-8)
-    c.D_opt_kwargs = dnnlib.EasyDict(class_name='torch.optim.Adam', betas=[0,0.99], eps=1e-8)
+    c.G_opt_kwargs = dnnlib.EasyDict(class_name='torch.optim.Adam', betas=[0.0,0.99], eps=1e-8)
+    c.D_opt_kwargs = dnnlib.EasyDict(class_name='torch.optim.Adam', betas=[0.0,0.99], eps=1e-8)
     c.loss_kwargs = dnnlib.EasyDict(class_name='training.loss.StyleGAN2Loss')
     c.data_loader_kwargs = dnnlib.EasyDict(pin_memory=True, prefetch_factor=2)
 


### PR DESCRIPTION
While using the train APIs in my own code, it is giving error that both parameters shall be float
This change fixes the issue.


```
StyleGAN3: File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1161, in __call__
2025-04-30 10:01:21,396 - INFO - [models_init] - StyleGAN3: return self.main(*args, **kwargs)
2025-04-30 10:01:21,396 - INFO - [models_init] - StyleGAN3: ^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-04-30 10:01:21,396 - INFO - [models_init] - StyleGAN3: File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1082, in main
2025-04-30 10:01:21,396 - INFO - [models_init] - StyleGAN3: rv = self.invoke(ctx)
2025-04-30 10:01:21,397 - INFO - [models_init] - StyleGAN3: ^^^^^^^^^^^^^^^^
2025-04-30 10:01:21,397 - INFO - [models_init] - StyleGAN3: File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 1443, in invoke
2025-04-30 10:01:21,397 - INFO - [models_init] - StyleGAN3: return ctx.invoke(self.callback, **ctx.params)
2025-04-30 10:01:21,397 - INFO - [models_init] - StyleGAN3: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-04-30 10:01:21,398 - INFO - [models_init] - StyleGAN3: File "/usr/local/lib/python3.11/dist-packages/click/core.py", line 788, in invoke
2025-04-30 10:01:21,398 - INFO - [models_init] - StyleGAN3: return __callback(*args, **kwargs)
2025-04-30 10:01:21,398 - INFO - [models_init] - StyleGAN3: ^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-04-30 10:01:21,398 - INFO - [models_init] - StyleGAN3: File "/content/cv_face/models/stylegan3/train.py", line 281, in main
2025-04-30 10:01:21,398 - INFO - [models_init] - StyleGAN3: launch_training(c=c, desc=desc, outdir=opts.outdir, dry_run=opts.dry_run)
2025-04-30 10:01:21,398 - INFO - [models_init] - StyleGAN3: File "/content/cv_face/models/stylegan3/train.py", line 96, in launch_training
2025-04-30 10:01:21,398 - INFO - [models_init] - StyleGAN3: subprocess_fn(rank=0, c=c, temp_dir=temp_dir)
2025-04-30 10:01:21,399 - INFO - [models_init] - StyleGAN3: File "/content/cv_face/models/stylegan3/train.py", line 47, in subprocess_fn
2025-04-30 10:01:21,399 - INFO - [models_init] - StyleGAN3: training_loop.training_loop(rank=rank, **c)
2025-04-30 10:01:21,399 - INFO - [models_init] - StyleGAN3: File "/content/cv_face/models/stylegan3/training/training_loop.py", line 197, in training_loop
2025-04-30 10:01:21,399 - INFO - [models_init] - StyleGAN3: opt = dnnlib.util.construct_class_by_name(params=module.parameters(), **opt_kwargs) # subclass of torch.optim.Optimizer
2025-04-30 10:01:21,400 - INFO - [models_init] - StyleGAN3: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-04-30 10:01:21,400 - INFO - [models_init] - StyleGAN3: File "/content/cv_face/models/stylegan3/dnnlib/util.py", line 303, in construct_class_by_name
2025-04-30 10:01:21,400 - INFO - [models_init] - StyleGAN3: return call_func_by_name(*args, func_name=class_name, **kwargs)
2025-04-30 10:01:21,400 - INFO - [models_init] - StyleGAN3: ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
2025-04-30 10:01:21,400 - INFO - [models_init] - StyleGAN3: File "/content/cv_face/models/stylegan3/dnnlib/util.py", line 298, in call_func_by_name
2025-04-30 10:01:21,401 - INFO - [models_init] - StyleGAN3: return func_obj(*args, **kwargs)
2025-04-30 10:01:21,401 - INFO - [models_init] - StyleGAN3: ^^^^^^^^^^^^^^^^^^^^^^^^^
2025-04-30 10:01:21,401 - INFO - [models_init] - StyleGAN3: File "/usr/local/lib/python3.11/dist-packages/torch/optim/adam.py", line 71, in __init__
2025-04-30 10:01:21,402 - INFO - [models_init] - StyleGAN3: raise ValueError("betas must be either both floats or both Tensors")
2025-04-30 10:01:21,402 - INFO - [models_init] - StyleGAN3: ValueError: betas must be either both floats or both Tensors
2025-04-30 10:01:22,292 - ERROR - [models_init] - StyleGAN3 training failed with return code 1
2025-04-30 10:01:22,292 - INFO - [models_init] - StyleGAN3 finetuning task finished.
```